### PR TITLE
[WW-3914] Remove duplicated touch events from button component

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -40,14 +40,6 @@ Features:
 Events:
 - focus: Triggered when button receives focus. No payload.
 - blur: Triggered when button loses focus. No payload.
-- mousedown: Triggered when mouse button is pressed on the button. No payload.
-- mouseup: Triggered when mouse button is released on the button. No payload.
-- mouseleave: Triggered when mouse leaves the button area. No payload.
-- touchstart: Triggered when touch begins on the button (mobile). No payload.
-- touchend: Triggered when touch ends on the button (mobile). No payload.
-- touchcancel: Triggered when touch is cancelled (mobile). No payload.
-- keydown: Triggered when a key is pressed while button has focus. No payload.
-- keyup: Triggered when a key is released while button has focus. No payload.
 
 States:
 - focus: Applied when the button has focus.

--- a/AI.md
+++ b/AI.md
@@ -40,6 +40,8 @@ Features:
 Events:
 - focus: Triggered when button receives focus. No payload.
 - blur: Triggered when button loses focus. No payload.
+- keydown: Triggered when a key is pressed while button has focus. No payload.
+- keyup: Triggered when a key is released while button has focus. No payload.
 
 States:
 - focus: Applied when the button has focus.

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -10,16 +10,16 @@
         v-bind="properties"
         @focus="isReallyFocused = true"
         @blur="onBlur($event)"
-        @mousedown="onActivate"
-        @mouseup="onDeactivate"
-        @mouseleave="onDeactivate"
-        @touchstart="onActivate"
-        @touchend="onDeactivate"
-        @touchcancel="onDeactivate"
-        @keydown.enter="onActivate"
-        @keydown.space="onActivate"
-        @keyup.enter="onDeactivate"
-        @keyup.space="onDeactivate"
+        @mousedown="onMouseActivate"
+        @mouseup="onMouseDeactivate"
+        @mouseleave="onMouseDeactivate"
+        @touchstart="onTouchActivate"
+        @touchend="onTouchDeactivate"
+        @touchcancel="onTouchDeactivate"
+        @keydown.enter="onKeyActivate"
+        @keydown.space="onKeyActivate"
+        @keyup.enter="onKeyDeactivate"
+        @keyup.space="onKeyDeactivate"
     >
         <wwElement v-if="content.hasLeftIcon && content.leftIcon" v-bind="content.leftIcon"></wwElement>
         <wwText tag="span" :text="text"></wwText>
@@ -222,13 +222,31 @@ export default {
             this.isReallyActive = true;
             // Emit the original event name
             const eventName = event.type;
-            this.$emit('trigger-event', { name: eventName });
+            this.$emit('trigger-event', { name: eventName, event });
         },
         onDeactivate(event) {
             this.isReallyActive = false;
             // Emit the original event name
             const eventName = event.type;
-            this.$emit('trigger-event', { name: eventName });
+            this.$emit('trigger-event', { name: eventName, event });
+        },
+        onTouchActivate() {
+            this.isReallyActive = true;
+        },
+        onTouchDeactivate() {
+            this.isReallyActive = false;
+        },
+        onMouseActivate() {
+            this.isReallyActive = true;
+        },
+        onMouseDeactivate() {
+            this.isReallyActive = false;
+        },
+        onKeyActivate() {
+            this.isReallyActive = true;
+        },
+        onKeyDeactivate() {
+            this.isReallyActive = false;
         },
     },
 };

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -20,6 +20,8 @@
         @keydown.space="onKeyActivate"
         @keyup.enter="onKeyDeactivate"
         @keyup.space="onKeyDeactivate"
+        @keydown="onKeyDown"
+        @keyup="onKeyUp"
     >
         <wwElement v-if="content.hasLeftIcon && content.leftIcon" v-bind="content.leftIcon"></wwElement>
         <wwText tag="span" :text="text"></wwText>
@@ -247,6 +249,12 @@ export default {
         },
         onKeyDeactivate() {
             this.isReallyActive = false;
+        },
+        onKeyDown(event) {
+            this.$emit('trigger-event', { name: 'keydown', event });
+        },
+        onKeyUp(event) {
+            this.$emit('trigger-event', { name: 'keyup', event });
         },
     },
 };

--- a/ww-config.js
+++ b/ww-config.js
@@ -59,6 +59,8 @@ export default {
     triggerEvents: [
         { name: 'focus', label: { en: 'On focus' }, event: null },
         { name: 'blur', label: { en: 'On blur' }, event: null },
+        { name: 'keydown', label: { en: 'On key down' }, event: null },
+        { name: 'keyup', label: { en: 'On key up' }, event: null },
     ],
     properties: {
         backgroundColor: {

--- a/ww-config.js
+++ b/ww-config.js
@@ -59,14 +59,6 @@ export default {
     triggerEvents: [
         { name: 'focus', label: { en: 'On focus' }, event: null },
         { name: 'blur', label: { en: 'On blur' }, event: null },
-        { name: 'mousedown', label: { en: 'On mouse down' }, event: null },
-        { name: 'mouseup', label: { en: 'On mouse up' }, event: null },
-        { name: 'mouseleave', label: { en: 'On mouse leave' }, event: null },
-        { name: 'touchstart', label: { en: 'On touch start' }, event: null },
-        { name: 'touchend', label: { en: 'On touch end' }, event: null },
-        { name: 'touchcancel', label: { en: 'On touch cancel' }, event: null },
-        { name: 'keydown', label: { en: 'On key down' }, event: null },
-        { name: 'keyup', label: { en: 'On key up' }, event: null },
     ],
     properties: {
         backgroundColor: {


### PR DESCRIPTION
## Summary
- Remove touchstart, touchend, touchcancel from triggerEvents in ww-config.js as they are duplicated from the editor
- Create separate touch handlers that manage active state without triggering custom events
- Update AI.md documentation to reflect removed touch events
- Maintain mobile active state functionality while avoiding event duplication